### PR TITLE
Updated actions/upload-artifact from v3 to v4

### DIFF
--- a/.github/workflows/epitech-actions.yml
+++ b/.github/workflows/epitech-actions.yml
@@ -30,7 +30,7 @@ jobs:
           fi
 
       - name: Save style check report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: style-check-report
           path: epitech-actions-output-style.txt


### PR DESCRIPTION
See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/